### PR TITLE
fix: use a filename with .xlsx for temp storage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: karpi
 Type: Package
 Title: Direct R interface to the KoBo v2 API
-Version: 0.1.1
+Version: 0.1.2
 Authors@R:
     c(person(given = "Patrick",
              family = "Anker",

--- a/R/kpi_xlsform.R
+++ b/R/kpi_xlsform.R
@@ -9,28 +9,28 @@ fetch_xlsform <- function(asset_id) {
 }
 
 #' Fetch the XLSForm for a survey with asset ID `asset_id`
-#' 
+#'
 #' Downloads the current XLSForm for a survey with ID `asset_id`.
-#' 
+#'
 #' @param asset_id The survey's asset ID (found after the "/forms/" in the URL)
 #' @param file If not `NULL`, the path where the XLSForm should be saved
 #' @param verbose If `TRUE`, echos a message where the file was saved
 #' @return An `odk_xlsform` object, a `list()` with `id`, `survey`,
 #'   `choices`, and `settings` entries.
-#' @examples 
+#' @examples
 #' \dontrun{
-#'   # Form url is this: https://kf.kobotoolbox.org/#/forms/abcdefghijklmnop
-#'   # Asset ID is: abcdefghijklmnop
-#'   form <- karpi::kpi_get_xlsform("abcdefghijklmnop")
-#'   print(form$survey)
-#'   print(form$choices)
+#' # Form url is this: https://kf.kobotoolbox.org/#/forms/abcdefghijklmnop
+#' # Asset ID is: abcdefghijklmnop
+#' form <- karpi::kpi_get_xlsform("abcdefghijklmnop")
+#' print(form$survey)
+#' print(form$choices)
 #' }
 #' @export
 kpi_get_xlsform <- function(asset_id, file = NULL, verbose = TRUE) {
   bytes <- fetch_xlsform(asset_id)
 
   if (is.null(file)) {
-    file <- tempfile()
+    file <- file.path(tempdir(), "temp_mapping.xlsx")
     on.exit(unlink(file))
   } else {
     if (isTRUE(verbose)) {


### PR DESCRIPTION
openxlsx does not infer type from the file data but instead from the
file extension. Previously, this would just use tempfile(), but that
obviously does not use a .xlsx extension.
